### PR TITLE
feat: add funding balance checks and open-channel UX guard

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,6 +25,7 @@ const DEMO_EPISODE = {
 
 // Default configuration
 const DEFAULT_RPC_URL = 'http://127.0.0.1:8229';
+const FAUCET_URL = 'https://testnet.ckbapp.dev/';
 
 // Recipient pubkey is fixed at deploy time by the podcast owner
 const RECIPIENT_PUBKEY = process.env.NEXT_PUBLIC_RECIPIENT_PUBKEY || '';
@@ -131,6 +132,13 @@ export default function Home() {
                 channelStateName={fiberNode.channelStateName}
                 channelElapsed={fiberNode.channelElapsed}
                 availableBalance={fiberNode.availableBalance}
+                channelCount={fiberNode.channels.length}
+                peerCount={fiberNode.peers.length}
+                fundingAmountCkb={fiberNode.fundingAmountCkb}
+                fundingBalanceCkb={fiberNode.fundingBalanceCkb}
+                isFundingSufficient={fiberNode.isFundingSufficient}
+                fundingBalanceError={fiberNode.fundingBalanceError}
+                faucetUrl={FAUCET_URL}
                 recipientPubkey={RECIPIENT_PUBKEY}
                 onCheckRoute={() => fiberNode.checkPaymentRoute(RECIPIENT_PUBKEY)}
                 onOpenChannel={() => fiberNode.setupChannel(RECIPIENT_PUBKEY)}

--- a/src/components/NodeStatus.tsx
+++ b/src/components/NodeStatus.tsx
@@ -3,7 +3,7 @@
 import { ReactNode, useState, useEffect } from 'react';
 import { motion } from 'motion/react';
 import { ChannelStatus } from '@/hooks/use-fiber-node';
-import { NodeInfo, fromHex } from '@/lib/fiber-rpc';
+import { NodeInfo } from '@/lib/fiber-rpc';
 import { ConnectionErrorModal } from './ConnectionErrorModal';
 
 interface NodeStatusProps {
@@ -20,6 +20,13 @@ interface NodeStatusProps {
   channelStateName?: string | null;
   channelElapsed?: number;
   availableBalance?: string;
+  channelCount?: number;
+  peerCount?: number;
+  fundingAmountCkb?: number;
+  fundingBalanceCkb?: number | null;
+  isFundingSufficient?: boolean;
+  fundingBalanceError?: string | null;
+  faucetUrl?: string;
   onCheckRoute?: () => void;
   onOpenChannel?: () => void;
   onCancelSetup?: () => void;
@@ -40,6 +47,13 @@ export function NodeStatus({
   channelStateName,
   channelElapsed = 0,
   availableBalance = '0',
+  channelCount = 0,
+  peerCount = 0,
+  fundingAmountCkb = 1000,
+  fundingBalanceCkb = null,
+  isFundingSufficient = false,
+  fundingBalanceError,
+  faucetUrl,
   onCheckRoute,
   onOpenChannel,
   onCancelSetup,
@@ -76,6 +90,7 @@ export function NodeStatus({
 
   const channelStatusDisplay = getChannelStatusDisplay();
   const isChannelBusy = channelStatus === 'checking' || channelStatus === 'opening_channel' || channelStatus === 'waiting_confirmation';
+  const shouldDisableOpenChannel = isChannelBusy || !isFundingSufficient;
 
   return (
     <div className="relative overflow-visible rounded-2xl bg-fiber-surface/50 backdrop-blur-sm border border-fiber-border p-5">
@@ -169,7 +184,7 @@ export function NodeStatus({
                   Channels
                 </p>
                 <p className="text-xl font-display text-white">
-                  {Number(fromHex(nodeInfo.channel_count))}
+                  {channelCount}
                 </p>
               </div>
               <div className="p-3 rounded-lg bg-fiber-dark/50">
@@ -177,10 +192,37 @@ export function NodeStatus({
                   Peers
                 </p>
                 <p className="text-xl font-display text-white">
-                  {Number(fromHex(nodeInfo.peers_count))}
+                  {peerCount}
                 </p>
               </div>
             </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="p-3 rounded-lg bg-fiber-dark/50">
+                <p className="text-[10px] text-fiber-muted font-mono uppercase tracking-wider mb-1">
+                  Funding Amount
+                </p>
+                <p className="text-sm font-display text-white">
+                  {fundingAmountCkb} CKB
+                </p>
+              </div>
+              <div className="p-3 rounded-lg bg-fiber-dark/50">
+                <p className="text-[10px] text-fiber-muted font-mono uppercase tracking-wider mb-1">
+                  Funding Balance
+                </p>
+                <p className="text-sm font-display text-white">
+                  {fundingBalanceCkb === null ? 'N/A' : `${fundingBalanceCkb.toFixed(4)} CKB`}
+                </p>
+              </div>
+            </div>
+
+            {fundingBalanceError && (
+              <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/30">
+                <p className="text-xs text-red-400 font-mono">
+                  Funding balance check failed: {fundingBalanceError}
+                </p>
+              </div>
+            )}
 
             <div className="p-3 rounded-lg bg-fiber-dark/50">
               <p className="text-[10px] text-fiber-muted font-mono uppercase tracking-wider mb-1">
@@ -307,12 +349,33 @@ export function NodeStatus({
               </motion.div>
             )}
 
-            <div className="flex gap-2">
+            {!isFundingSufficient && (channelStatus === 'no_route' || channelStatus === 'error') && (
+              <div className="mb-2 p-2 rounded-lg bg-red-500/10 border border-red-500/30">
+                <p className="text-xs text-red-400">
+                  Funding balance is below {fundingAmountCkb} CKB. Please top up from faucet first before opening a channel.
+                  {faucetUrl && (
+                    <>
+                      {' '}
+                      <a
+                        href={faucetUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline text-red-300 hover:text-red-200"
+                      >
+                        Go to faucet
+                      </a>
+                    </>
+                  )}
+                </p>
+              </div>
+            )}
+
+            <div className="flex items-stretch gap-2">
               {onCheckRoute && (
                 <button
                   onClick={onCheckRoute}
                   disabled={isChannelBusy}
-                  className="flex-1 py-2 px-3 text-xs font-mono uppercase tracking-wider rounded-lg bg-fiber-dark/50 text-fiber-muted hover:text-fiber-accent hover:bg-fiber-accent/10 border border-fiber-border hover:border-fiber-accent/30 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="flex-1 py-2 px-3 min-h-12 text-xs font-mono uppercase tracking-wider rounded-lg bg-fiber-dark/50 text-fiber-muted hover:text-fiber-accent hover:bg-fiber-accent/10 border border-fiber-border hover:border-fiber-accent/30 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {channelStatus === 'ready' ? 'Re-check' : 'Check Route'}
                 </button>
@@ -321,8 +384,8 @@ export function NodeStatus({
               {onOpenChannel && (channelStatus === 'no_route' || channelStatus === 'error') && (
                 <button
                   onClick={onOpenChannel}
-                  disabled={isChannelBusy}
-                  className="flex-1 py-2 px-3 text-xs font-mono uppercase tracking-wider rounded-lg bg-fiber-accent/20 text-fiber-accent hover:bg-fiber-accent/30 border border-fiber-accent/50 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                  disabled={shouldDisableOpenChannel}
+                  className="flex-1 py-2 px-3 min-h-12 text-xs font-mono uppercase tracking-wider rounded-lg bg-fiber-accent/20 text-fiber-accent hover:bg-fiber-accent/30 border border-fiber-accent/50 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Open Channel
                 </button>

--- a/src/hooks/use-fiber-node.ts
+++ b/src/hooks/use-fiber-node.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback, useRef } from 'react';
-import { FiberRpcClient, NodeInfo, Channel, PeerInfo, ChannelState, toHex, ckbToShannon, formatShannon } from '@/lib/fiber-rpc';
+import { FiberRpcClient, NodeInfo, Channel, PeerInfo, ChannelState, toHex, fromHex, ckbToShannon, formatShannon } from '@/lib/fiber-rpc';
 
 export type ChannelStatus =
   | 'idle'
@@ -28,12 +28,29 @@ export interface UseFiberNodeResult {
   channelStateName: string | null;
   channelElapsed: number;
   availableBalance: string;
+  fundingAmountCkb: number;
+  fundingBalanceCkb: number | null;
+  isFundingSufficient: boolean;
+  fundingBalanceError: string | null;
   checkPaymentRoute: (recipientPubkey: string, amount?: number) => Promise<boolean>;
   setupChannel: (recipientPubkey: string, fundingAmountCkb?: number) => Promise<boolean>;
   cancelChannelSetup: () => void;
 }
 
-const DEFAULT_FUNDING_AMOUNT_CKB = 100; // 100 CKB default funding
+const DEFAULT_FUNDING_AMOUNT_CKB = 1000; // 1000 CKB default funding
+const CKB_RPC_URL = 'https://testnet.ckbapp.dev/';
+
+interface GetCellsCapacityResult {
+  capacity: `0x${string}`;
+}
+
+interface JsonRpcResponse<T> {
+  result?: T;
+  error?: {
+    code: number;
+    message: string;
+  };
+}
 
 export function useFiberNode(rpcUrl: string): UseFiberNodeResult {
   const [isConnected, setIsConnected] = useState(false);
@@ -50,6 +67,8 @@ export function useFiberNode(rpcUrl: string): UseFiberNodeResult {
   const [channelStateName, setChannelStateName] = useState<string | null>(null);
   const [channelElapsed, setChannelElapsed] = useState(0);
   const [availableBalance, setAvailableBalance] = useState('0');
+  const [fundingBalanceCkb, setFundingBalanceCkb] = useState<number | null>(null);
+  const [fundingBalanceError, setFundingBalanceError] = useState<string | null>(null);
   const channelSetupCanceledRef = useRef(false);
   const channelTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -69,6 +88,55 @@ export function useFiberNode(rpcUrl: string): UseFiberNodeResult {
     }, 1000);
   }, [clearChannelTimer]);
 
+  const fetchFundingBalance = useCallback(async (info: NodeInfo) => {
+    try {
+      const response = await fetch(CKB_RPC_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'get_cells_capacity',
+          params: [
+            {
+              script: info.default_funding_lock_script,
+              script_type: 'lock',
+            },
+          ],
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`CKB RPC HTTP ${response.status}`);
+      }
+
+      const payload = (await response.json()) as JsonRpcResponse<GetCellsCapacityResult>;
+      if (payload.error) {
+        throw new Error(payload.error.message || 'CKB RPC error');
+      }
+
+      const capacityHex = payload.result?.capacity;
+      if (!capacityHex) {
+        throw new Error('No capacity returned from CKB RPC');
+      }
+
+      const capacityShannon = fromHex(capacityHex);
+      const capacityCkb = Number(capacityShannon) / 100_000_000;
+
+      if (!Number.isFinite(capacityCkb)) {
+        throw new Error('Invalid funding balance from CKB RPC');
+      }
+
+      setFundingBalanceCkb(capacityCkb);
+      setFundingBalanceError(null);
+    } catch (err) {
+      setFundingBalanceCkb(null);
+      setFundingBalanceError(err instanceof Error ? err.message : 'Failed to fetch funding balance');
+    }
+  }, []);
+
   const connect = useCallback(async () => {
     setIsConnecting(true);
     setError(null);
@@ -79,6 +147,7 @@ export function useFiberNode(rpcUrl: string): UseFiberNodeResult {
 
       const info = await client.nodeInfo();
       setNodeInfo(info);
+      await fetchFundingBalance(info);
 
       const channelResult = await client.listChannels();
       setChannels(channelResult.channels || []);
@@ -93,7 +162,7 @@ export function useFiberNode(rpcUrl: string): UseFiberNodeResult {
     } finally {
       setIsConnecting(false);
     }
-  }, [rpcUrl]);
+  }, [fetchFundingBalance, rpcUrl]);
 
   const disconnect = useCallback(() => {
     clientRef.current = null;
@@ -109,6 +178,8 @@ export function useFiberNode(rpcUrl: string): UseFiberNodeResult {
     channelSetupCanceledRef.current = false;
     clearChannelTimer();
     setAvailableBalance('0');
+    setFundingBalanceCkb(null);
+    setFundingBalanceError(null);
   }, [clearChannelTimer]);
 
   const refresh = useCallback(async () => {
@@ -117,6 +188,7 @@ export function useFiberNode(rpcUrl: string): UseFiberNodeResult {
     try {
       const info = await clientRef.current.nodeInfo();
       setNodeInfo(info);
+      await fetchFundingBalance(info);
 
       const channelResult = await clientRef.current.listChannels();
       setChannels(channelResult.channels || []);
@@ -126,7 +198,7 @@ export function useFiberNode(rpcUrl: string): UseFiberNodeResult {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to refresh');
     }
-  }, []);
+  }, [fetchFundingBalance]);
 
   const checkPaymentRoute = useCallback(
     async (recipientPubkey: string, amount: number = 0.01): Promise<boolean> => {
@@ -214,6 +286,15 @@ export function useFiberNode(rpcUrl: string): UseFiberNodeResult {
 
       if (!recipientPubkey.trim()) {
         setChannelError('Select a recipient peer or enter a recipient public key first.');
+        setChannelStatus('error');
+        return false;
+      }
+
+      if (fundingBalanceCkb !== null && fundingBalanceCkb < fundingAmountCkb) {
+        setChannelError(
+          `Insufficient funding balance (${fundingBalanceCkb.toFixed(4)} CKB). ` +
+          `Need ${fundingAmountCkb} CKB. Please top up from faucet first.`
+        );
         setChannelStatus('error');
         return false;
       }
@@ -327,8 +408,11 @@ export function useFiberNode(rpcUrl: string): UseFiberNodeResult {
         return false;
       }
     },
-    [clearChannelTimer, startChannelTimer]
+    [clearChannelTimer, fundingBalanceCkb, startChannelTimer]
   );
+
+  const isFundingSufficient =
+    fundingBalanceCkb !== null && fundingBalanceCkb >= DEFAULT_FUNDING_AMOUNT_CKB;
 
   return {
     isConnected,
@@ -345,6 +429,10 @@ export function useFiberNode(rpcUrl: string): UseFiberNodeResult {
     channelStateName,
     channelElapsed,
     availableBalance,
+    fundingAmountCkb: DEFAULT_FUNDING_AMOUNT_CKB,
+    fundingBalanceCkb,
+    isFundingSufficient,
+    fundingBalanceError,
     checkPaymentRoute,
     setupChannel,
     cancelChannelSetup,


### PR DESCRIPTION
## Summary\n- add funding balance query via CKB RPC using default funding lock script\n- show funding amount and funding balance on node panel\n- disable `Open Channel` when funding balance is below required amount and show faucet prompt\n- switch displayed channel/peer counts to frontend list lengths (channels.length / peers.length)\n- improve open-channel action area layout for consistent button alignment\n\n## Validation\n- pnpm exec tsc --noEmit\n\n## Notes\n- this PR intentionally only includes app/hook/component code changes\n- local env file changes are not included