### PR TITLE
fix(systemd): add EnvironmentFile pointing to backend/.env

### DIFF
--- a/scripts/systemd/fiber-audio-backend.service
+++ b/scripts/systemd/fiber-audio-backend.service
@@ -23,6 +23,7 @@ StartLimitBurst=3
 # Environment
 Environment="NODE_ENV=production"
 Environment="PORT=8787"
+EnvironmentFile=%PROJECT_ROOT%/backend/.env
 
 # Logging
 StandardOutput=journal


### PR DESCRIPTION
## Problem
The backend service was not loading `INVOICE_CURRENCY` and other environment variables because dotenv loads from `process.cwd()`, which is the project root, not the backend directory.

## Solution
Add `EnvironmentFile=%PROJECT_ROOT%/backend/.env` to the systemd service file to ensure all backend env vars are loaded correctly.

## Changes
- Added `scripts/systemd/fiber-audio-backend.service` with `EnvironmentFile` directive

Fixes the issue where backend uses default `Fibd` currency instead of configured `Fibt`.