### PR TITLE
fix: make HLS media serving stable in systemd production

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import { cors } from 'hono/cors'
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import { createHash, randomUUID } from 'node:crypto'
+import { fileURLToPath } from 'node:url'
 import { blake2b } from '@noble/hashes/blake2.js'
 import {
   FiberRpcClient,
@@ -108,7 +109,17 @@ function derivePaymentHash(preimageBytes: Uint8Array, algorithm: InvoiceHashAlgo
 
 const segmentDurationSec = Number(process.env.HLS_SEGMENT_DURATION_SEC ?? 6)
 const authTtlSec = Number(process.env.STREAM_AUTH_TTL_SEC ?? 300)
-const hlsDir = path.resolve(process.cwd(), process.env.HLS_DIR ?? '../media/hls')
+
+// Resolve media path relative to backend root so runtime CWD (systemd, pnpm, etc.)
+// does not affect where HLS assets are loaded from.
+const currentFilePath = fileURLToPath(import.meta.url)
+const backendRootDir = path.resolve(path.dirname(currentFilePath), '..')
+const hlsDirFromEnv = process.env.HLS_DIR?.trim()
+const hlsDir = hlsDirFromEnv
+  ? (path.isAbsolute(hlsDirFromEnv)
+      ? path.normalize(hlsDirFromEnv)
+      : path.resolve(backendRootDir, hlsDirFromEnv))
+  : path.resolve(backendRootDir, '../media/hls')
 
 function toSegmentIndex(seconds: number): number {
   return Math.max(0, Math.ceil(seconds / segmentDurationSec) - 1)

--- a/scripts/systemd/fiber-audio-backend.service
+++ b/scripts/systemd/fiber-audio-backend.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 Type=simple
 User=root
-WorkingDirectory=%PROJECT_ROOT%
+WorkingDirectory=%PROJECT_ROOT%/backend
 
 # Pre-start: install dependencies and build
 ExecStartPre=/bin/bash -c 'cd %PROJECT_ROOT% && pnpm install && pnpm build:api'


### PR DESCRIPTION
## Summary
- fix backend HLS media directory resolution so it no longer depends on process cwd
- resolve HLS_DIR relative to backend runtime file location (import.meta.url)
- set systemd WorkingDirectory to %PROJECT_ROOT%/backend to align production runtime context

## Root Cause
In production, systemd used %PROJECT_ROOT% as cwd while backend/.env had HLS_DIR=../media/hls. Previous code resolved HLS path from process.cwd(), which pointed to the wrong directory and caused media 404s.

## Verification
- pnpm -C backend build passes
