### PR TITLE
refactor(ui): suppor wasm and improve connect panel flow for node modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,11 @@ See [docs/cli.md](docs/cli.md) for full CLI documentation.
 Copy `.env.local.example` to `.env.local` and configure:
 
 ```bash
-# Required: Your Fiber node pubkey for receiving payments
-NEXT_PUBLIC_RECIPIENT_PUBKEY=03abc...your_pubkey_hex
+# Optional: Backend URL (frontend fetches recipient pubkey from backend /node-info)
+NEXT_PUBLIC_BACKEND_BASE_URL=http://localhost:8787
 
 # Optional: Bootnode multiaddr for listener auto-bootstrap
 NEXT_PUBLIC_BOOTNODE_MULTIADDR=/ip4/127.0.0.1/tcp/8228/p2p/Qm...
-
-# Optional: Backend URL
-NEXT_PUBLIC_BACKEND_BASE_URL=http://localhost:8787
 
 # Optional: Payment interval (default: 10 seconds)
 NEXT_PUBLIC_PAYMENT_INTERVAL_MS=10000

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@fiber-pay/sdk": "0.2.0",
+    "@fiber-pay/sdk": "0.2.1",
     "@hono/node-server": "^1.19.4",
     "@noble/hashes": "^2.0.1",
     "better-sqlite3": "^12.6.2",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -338,13 +338,33 @@ app.get('/healthz', (c) => c.json({ ok: true, service: 'fiber-audio-backend' }))
 app.get('/node-info', async (c) => {
   try {
     const info = await fiberClient.nodeInfo()
+    const raw = info as unknown as Record<string, unknown>
+    const nodeId =
+      (typeof raw.pubkey === 'string' ? raw.pubkey : null) ??
+      (typeof raw.node_id === 'string' ? raw.node_id : null) ??
+      (typeof raw.nodeId === 'string' ? raw.nodeId : null)
+
+    if (!nodeId) {
+      return c.json(
+        {
+          ok: false,
+          error:
+            'Fiber node info is missing identifier field (pubkey/node_id). Check FNN version and SDK compatibility.',
+        },
+        502,
+      )
+    }
+
     return c.json({
       ok: true,
       node: {
-        nodeName: info.node_name,
-        nodeId: info.pubkey,
-        addresses: info.addresses,
-        openChannelAutoAcceptMin: info.open_channel_auto_accept_min_ckb_funding_amount,
+        nodeName: (typeof raw.node_name === 'string' || raw.node_name === null ? raw.node_name : null),
+        nodeId,
+        addresses: Array.isArray(raw.addresses) ? raw.addresses : [],
+        openChannelAutoAcceptMin:
+          (typeof raw.open_channel_auto_accept_min_ckb_funding_amount === 'string'
+            ? raw.open_channel_auto_accept_min_ckb_funding_amount
+            : null),
       },
     })
   } catch (err) {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,7 @@ import path from 'node:path'
 import { createHash, randomUUID } from 'node:crypto'
 import { fileURLToPath } from 'node:url'
 import { blake2b } from '@noble/hashes/blake2.js'
+import { z } from 'zod'
 import {
   FiberRpcClient,
   randomBytes32,
@@ -79,6 +80,17 @@ function resolveInvoiceHashAlgorithm(value: string | undefined): InvoiceHashAlgo
 const INVOICE_HASH_ALGORITHM = resolveInvoiceHashAlgorithm(process.env.INVOICE_HASH_ALGORITHM)
 
 const fiberClient = new FiberRpcClient({ url: FIBER_RPC_URL, timeout: 15_000 })
+
+const nodeInfoResponseSchema = z
+  .object({
+    pubkey: z.string().optional(),
+    node_id: z.string().optional(),
+    nodeId: z.string().optional(),
+    node_name: z.string().nullable().optional(),
+    addresses: z.array(z.string()).optional(),
+    open_channel_auto_accept_min_ckb_funding_amount: z.string().optional(),
+  })
+  .passthrough()
 
 // ---------------------------------------------------------------------------
 // Types
@@ -338,11 +350,23 @@ app.get('/healthz', (c) => c.json({ ok: true, service: 'fiber-audio-backend' }))
 app.get('/node-info', async (c) => {
   try {
     const info = await fiberClient.nodeInfo()
-    const raw = info as unknown as Record<string, unknown>
+    const parsed = nodeInfoResponseSchema.safeParse(info)
+    if (!parsed.success) {
+      return c.json(
+        {
+          ok: false,
+          error:
+            'Fiber node info response is invalid. Check FNN version and SDK compatibility.',
+        },
+        502,
+      )
+    }
+
+    const raw = parsed.data
     const nodeId =
-      (typeof raw.pubkey === 'string' ? raw.pubkey : null) ??
-      (typeof raw.node_id === 'string' ? raw.node_id : null) ??
-      (typeof raw.nodeId === 'string' ? raw.nodeId : null)
+      raw.pubkey ??
+      raw.node_id ??
+      raw.nodeId
 
     if (!nodeId) {
       return c.json(
@@ -358,13 +382,10 @@ app.get('/node-info', async (c) => {
     return c.json({
       ok: true,
       node: {
-        nodeName: (typeof raw.node_name === 'string' || raw.node_name === null ? raw.node_name : null),
+        nodeName: raw.node_name ?? null,
         nodeId,
-        addresses: Array.isArray(raw.addresses) ? raw.addresses : [],
-        openChannelAutoAcceptMin:
-          (typeof raw.open_channel_auto_accept_min_ckb_funding_amount === 'string'
-            ? raw.open_channel_auto_accept_min_ckb_funding_amount
-            : null),
+        addresses: raw.addresses ?? [],
+        openChannelAutoAcceptMin: raw.open_channel_auto_accept_min_ckb_funding_amount ?? null,
       },
     })
   } catch (err) {

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,28 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const securityHeaders = [
+	{
+		key: 'Cross-Origin-Opener-Policy',
+		value: 'same-origin',
+	},
+	{
+		key: 'Cross-Origin-Embedder-Policy',
+		value: 'require-corp',
+	},
+	{
+		key: 'Origin-Agent-Cluster',
+		value: '?1',
+	},
+]
+
+const nextConfig = {
+	async headers() {
+		return [
+			{
+				source: '/:path*',
+				headers: securityHeaders,
+			},
+		]
+	},
+}
 
 module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "typecheck:api": "pnpm -C backend typecheck"
   },
   "dependencies": {
-    "@fiber-pay/sdk": "0.2.0",
+    "@fiber-pay/sdk": "0.2.1",
+    "@nervosnetwork/fiber-js": "~0.8.0",
     "hls.js": "^1.6.13",
     "motion": "^12.4.7",
     "next": "15.5.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,11 @@ importers:
   .:
     dependencies:
       '@fiber-pay/sdk':
-        specifier: 0.2.0
-        version: 0.2.0
+        specifier: 0.2.1
+        version: 0.2.1(@nervosnetwork/fiber-js@0.8.0)
+      '@nervosnetwork/fiber-js':
+        specifier: ~0.8.0
+        version: 0.8.0
       hls.js:
         specifier: ^1.6.13
         version: 1.6.15
@@ -110,8 +113,8 @@ importers:
   backend:
     dependencies:
       '@fiber-pay/sdk':
-        specifier: 0.2.0
-        version: 0.2.0
+        specifier: 0.2.1
+        version: 0.2.1(@nervosnetwork/fiber-js@0.8.0)
       '@hono/node-server':
         specifier: ^1.19.4
         version: 1.19.10(hono@4.12.4)
@@ -366,8 +369,8 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@fiber-pay/sdk@0.2.0':
-    resolution: {integrity: sha512-HwI7CpeX5vFZ4SwIfK+V2jc8KYm5GH0AaLlhOLTG7/ZJzbbyvjRJYNAMO4YHtzZ/UEmBQRfs+DHv7QZinIfUgg==}
+  '@fiber-pay/sdk@0.2.1':
+    resolution: {integrity: sha512-6W7Wa5mqnlEr//xXv7rLXe/EOHPRPyL+yAEft4cY0jiLNWZvyMUhlKh0LAPaX9v7N7v+KqdVI2hLHwFepxKuWQ==}
     engines: {node: '>=20'}
     peerDependencies:
       '@nervosnetwork/fiber-js': ~0.8.0
@@ -581,6 +584,9 @@ packages:
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
+  '@nervosnetwork/fiber-js@0.8.0':
+    resolution: {integrity: sha512-R7gTpsQD1IYOpG4CehHYHdTsvHnoxQ4i7rF9cWLxvKO2PzDeZFfgavcwh7320AZhynR7eg7fm+g+xAmquvWS6w==}
 
   '@next/env@15.5.12':
     resolution: {integrity: sha512-pUvdJN1on574wQHjaBfNGDt9Mz5utDSZFsIIQkMzPgNS8ZvT4H2mwOrOIClwsQOb6EGx5M76/CZr6G8i6pSpLg==}
@@ -1161,6 +1167,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  async-mutex@0.5.0:
+    resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -2598,6 +2607,9 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  stream-browserify@3.0.0:
+    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -3080,11 +3092,13 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@fiber-pay/sdk@0.2.0':
+  '@fiber-pay/sdk@0.2.1(@nervosnetwork/fiber-js@0.8.0)':
     dependencies:
       '@noble/hashes': 2.0.1
       macaroon: 3.0.4
       zod: 4.3.6
+    optionalDependencies:
+      '@nervosnetwork/fiber-js': 0.8.0
 
   '@hono/node-server@1.19.10(hono@4.12.4)':
     dependencies:
@@ -3227,6 +3241,11 @@ snapshots:
       '@emnapi/runtime': 1.8.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@nervosnetwork/fiber-js@0.8.0':
+    dependencies:
+      async-mutex: 0.5.0
+      stream-browserify: 3.0.0
 
   '@next/env@15.5.12': {}
 
@@ -3738,6 +3757,10 @@ snapshots:
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
+
+  async-mutex@0.5.0:
+    dependencies:
+      tslib: 2.8.1
 
   asynckit@0.4.0: {}
 
@@ -5386,6 +5409,11 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  stream-browserify@3.0.0:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   string-width@4.2.3:
     dependencies:

--- a/public/default-cover.svg
+++ b/public/default-cover.svg
@@ -1,0 +1,25 @@
+<svg width="1200" height="1200" viewBox="0 0 1200 1200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="1200" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0B0F14" />
+      <stop offset="1" stop-color="#111C2B" />
+    </linearGradient>
+    <linearGradient id="ring" x1="300" y1="300" x2="900" y2="900" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#00FFA3" />
+      <stop offset="1" stop-color="#00D4FF" />
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="1200" fill="url(#bg)" />
+  <circle cx="600" cy="600" r="360" stroke="url(#ring)" stroke-width="24" opacity="0.9" />
+  <circle cx="600" cy="600" r="250" stroke="#1E293B" stroke-width="2" opacity="0.8" />
+
+  <g opacity="0.9">
+    <rect x="435" y="520" width="48" height="160" rx="10" fill="#E2E8F0" />
+    <rect x="521" y="460" width="48" height="220" rx="10" fill="#E2E8F0" />
+    <rect x="607" y="500" width="48" height="180" rx="10" fill="#E2E8F0" />
+    <rect x="693" y="560" width="48" height="120" rx="10" fill="#E2E8F0" />
+  </g>
+
+  <text x="600" y="780" text-anchor="middle" fill="#94A3B8" font-size="44" font-family="monospace" letter-spacing="2">FIBER AUDIO</text>
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,13 +1,8 @@
-@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400;500&family=JetBrains+Mono:wght@400;500&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 :root {
-  --font-display: 'Cormorant Garamond', serif;
-  --font-mono: 'JetBrains Mono', monospace;
-
   --color-fiber-dark: #0a0a0f;
   --color-fiber-deeper: #050508;
   --color-fiber-surface: #12121a;
@@ -29,7 +24,7 @@ html,
 body {
   max-width: 100vw;
   overflow-x: hidden;
-  font-family: var(--font-mono);
+  font-family: var(--font-mono), monospace;
 }
 
 body {
@@ -65,11 +60,11 @@ body {
 
 /* Font classes */
 .font-display {
-  font-family: var(--font-display);
+  font-family: var(--font-display), serif;
 }
 
 .font-mono {
-  font-family: var(--font-mono);
+  font-family: var(--font-mono), monospace;
 }
 
 /* Gradient text */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,18 @@
 import type { Metadata } from 'next';
+import { Cormorant_Garamond, JetBrains_Mono } from 'next/font/google';
 import './globals.css';
+
+const displayFont = Cormorant_Garamond({
+  subsets: ['latin'],
+  weight: ['300', '400', '500'],
+  variable: '--font-display',
+});
+
+const monoFont = JetBrains_Mono({
+  subsets: ['latin'],
+  weight: ['400', '500'],
+  variable: '--font-mono',
+});
 
 export const metadata: Metadata = {
   title: 'Fiber Audio Player - Stream. Listen. Pay.',
@@ -12,7 +25,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${displayFont.variable} ${monoFont.variable}`}>
       <body className="antialiased animated-gradient">
         {/* Noise texture overlay */}
         <div className="noise-overlay" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ import { PaymentHistory } from '@/components/PaymentHistory';
 import { PodcastList, Podcast } from '@/components/PodcastList';
 import { EpisodeList } from '@/components/EpisodeList';
 import { Episode } from '@/components/EpisodeCard';
-import { useFiberNode } from '@/hooks/use-fiber-node';
+import { useFiberNode, type NodeConnectionMode } from '@/hooks/use-fiber-node';
 import { useStreamingPayment } from '@/hooks/use-streaming-payment';
 import { getBackendNodeInfo } from '@/lib/stream-auth';
 
@@ -20,7 +20,7 @@ const FAUCET_URL = 'https://testnet.ckbapp.dev/';
 const BOOTNODE_MULTIADDR = process.env.NEXT_PUBLIC_BOOTNODE_MULTIADDR || '';
 
 // Default cover image for episodes
-const DEFAULT_COVER_URL = 'https://images.unsplash.com/photo-1614680376593-902f74cf0d41?w=400&h=400&fit=crop&auto=format';
+const DEFAULT_COVER_URL = '/default-cover.svg';
 
 /**
  * Convert backend Episode to AudioPlayer Episode format
@@ -64,6 +64,8 @@ function toAudioPlayerEpisode(episode: Episode): {
 
 export default function Home() {
   const [rpcUrl, setRpcUrl] = useState(DEFAULT_RPC_URL);
+  const [nodeMode, setNodeMode] = useState<NodeConnectionMode>('local-rpc');
+  const [passkeyDisplayName, setPasskeyDisplayName] = useState('Fiber Audio Listener');
   const [selectedPodcast, setSelectedPodcast] = useState<Podcast | null>(null);
   const [selectedEpisode, setSelectedEpisode] = useState<Episode | null>(null);
   const [isNodeDropdownOpen, setIsNodeDropdownOpen] = useState(false);
@@ -86,15 +88,27 @@ export default function Home() {
   const fiberNode = useFiberNode(rpcUrl, {
     recipientPubkey,
     bootnodeMultiaddr: BOOTNODE_MULTIADDR,
+    mode: nodeMode,
+    passkeyDisplayName,
+    browserNetwork: 'testnet',
   });
 
   const payment = useStreamingPayment({
     rpcUrl,
     recipientPubkey,
+    paymentClient: fiberNode.paymentClient,
     ratePerSecond: selectedEpisode 
       ? parseFloat(selectedEpisode.price_per_second) / 100_000_000 
       : 0.0001,
   });
+
+  const handleNodeModeChange = (nextMode: NodeConnectionMode) => {
+    if (nextMode === nodeMode) return;
+    if (fiberNode.isConnected) {
+      fiberNode.disconnect();
+    }
+    setNodeMode(nextMode);
+  };
 
   const handlePodcastSelect = (podcast: Podcast) => {
     setSelectedPodcast(podcast);
@@ -144,6 +158,13 @@ export default function Home() {
         onCancelSetup={fiberNode.cancelChannelSetup}
         rpcUrlValue={rpcUrl}
         onRpcUrlChange={setRpcUrl}
+        nodeMode={nodeMode}
+        onNodeModeChange={handleNodeModeChange}
+        passkeyDisplayName={passkeyDisplayName}
+        onPasskeyDisplayNameChange={setPasskeyDisplayName}
+        passkeySupported={fiberNode.passkeySupported}
+        passkeyConfigured={fiberNode.passkeyConfigured}
+        browserNodeState={fiberNode.browserNodeState}
         backendError={backendError}
         isDropdownOpen={isNodeDropdownOpen}
         onDropdownOpenChange={setIsNodeDropdownOpen}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -70,18 +70,19 @@ export default function Home() {
   const [selectedEpisode, setSelectedEpisode] = useState<Episode | null>(null);
   const [isNodeDropdownOpen, setIsNodeDropdownOpen] = useState(false);
 
-  // Auto-fetch the developer node's pubkey from backend /node-info
+  // Source of truth: backend /node-info
   const [recipientPubkey, setRecipientPubkey] = useState('');
   const [backendError, setBackendError] = useState<string | null>(null);
 
   useEffect(() => {
     getBackendNodeInfo()
       .then((info) => {
-        setRecipientPubkey(info.nodeId);
+        setRecipientPubkey((info.nodeId || '').trim());
         setBackendError(null);
       })
       .catch((err) => {
-        setBackendError(err instanceof Error ? err.message : 'Failed to reach backend');
+        setRecipientPubkey('');
+        setBackendError(err instanceof Error ? err.message : 'Failed to reach backend /node-info');
       });
   }, []);
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,8 @@ import { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import { NodeStatus } from './NodeStatus';
 import { NodeInfo } from '@/lib/fiber-rpc';
-import { ChannelStatus } from '@/hooks/use-fiber-node';
+import { ChannelStatus, type NodeConnectionMode } from '@/hooks/use-fiber-node';
+import type { BrowserNodeState } from '@fiber-pay/sdk/browser';
 
 interface HeaderProps {
   // Node status props
@@ -36,6 +37,13 @@ interface HeaderProps {
   // RPC URL config
   rpcUrlValue?: string;
   onRpcUrlChange?: (url: string) => void;
+  nodeMode?: NodeConnectionMode;
+  onNodeModeChange?: (mode: NodeConnectionMode) => void;
+  passkeyDisplayName?: string;
+  onPasskeyDisplayNameChange?: (value: string) => void;
+  passkeySupported?: boolean | null;
+  passkeyConfigured?: boolean;
+  browserNodeState?: BrowserNodeState;
   onRequestEditUrl?: () => void;
   isDropdownOpen?: boolean;
   onDropdownOpenChange?: (open: boolean) => void;
@@ -70,6 +78,13 @@ export function Header({
   recipientMultiaddrConfigured = false,
   rpcUrlValue,
   onRpcUrlChange,
+  nodeMode = 'local-rpc',
+  onNodeModeChange,
+  passkeyDisplayName = 'Fiber Audio Listener',
+  onPasskeyDisplayNameChange,
+  passkeySupported = null,
+  passkeyConfigured = false,
+  browserNodeState = 'idle',
   backendError,
   onRequestEditUrl,
   isDropdownOpen: controlledIsDropdownOpen,
@@ -104,15 +119,25 @@ export function Header({
   }, [setIsDropdownOpen]);
 
   useEffect(() => {
-    if (isDropdownOpen && inputRef.current) {
+    if (isDropdownOpen && nodeMode === 'local-rpc' && inputRef.current) {
       inputRef.current.focus();
       inputRef.current.select();
     }
-  }, [isDropdownOpen]);
+  }, [isDropdownOpen, nodeMode]);
 
   const getButtonStatus = () => {
-    if (isConnecting) return { text: 'Connecting...', color: 'bg-fiber-warning' };
-    if (!isConnected) return { text: 'Connect Node', color: 'bg-fiber-muted' };
+    if (isConnecting) {
+      return {
+        text: nodeMode === 'browser-passkey' ? 'Starting Browser Node...' : 'Connecting...',
+        color: 'bg-fiber-warning',
+      };
+    }
+    if (!isConnected) {
+      return {
+        text: nodeMode === 'browser-passkey' ? 'Start Browser Node' : 'Connect Node',
+        color: 'bg-fiber-muted',
+      };
+    }
     if (channelStatus === 'ready') return { text: 'Node Ready', color: 'bg-fiber-accent' };
     return { text: 'Node Connected', color: 'bg-fiber-accent' };
   };
@@ -256,23 +281,82 @@ export function Header({
                       onRequestEditUrl={onRequestEditUrl}
                       topConfigPanel={
                         !isConnected ? (
-                          <div>
-                            <label className="block text-xs text-fiber-muted/95 mb-2 font-mono uppercase tracking-wider">
-                              Connect To Your Fiber Node Via RPC URL
-                            </label>
-                            <div className="relative group">
-                              <input
-                                ref={inputRef}
-                                type="text"
-                                value={rpcUrlValue || rpcUrl}
-                                onChange={(e) => onRpcUrlChange?.(e.target.value)}
-                                className="w-full px-3 py-2 pr-10 bg-fiber-dark border border-fiber-border rounded-lg text-sm font-mono text-white focus:outline-none focus:border-fiber-accent focus:ring-1 focus:ring-fiber-accent/30 hover:bg-fiber-surface/50 transition-all duration-200"
-                                placeholder={rpcUrl}
-                              />
-                              <div className="absolute right-3 top-1/2 -translate-y-1/2 text-fiber-muted group-hover:text-fiber-accent transition-colors pointer-events-none">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>
+                          <div className="space-y-3">
+                            <div>
+                              <label className="block text-xs text-fiber-muted/95 mb-2 font-mono uppercase tracking-wider">
+                                Node Mode
+                              </label>
+                              <div className="grid grid-cols-2 gap-2">
+                                <button
+                                  type="button"
+                                  onClick={() => onNodeModeChange?.('local-rpc')}
+                                  className={`px-2.5 py-2 text-[11px] font-mono uppercase tracking-wider rounded-lg border transition-all ${
+                                    nodeMode === 'local-rpc'
+                                      ? 'bg-fiber-accent/20 text-fiber-accent border-fiber-accent/60'
+                                      : 'bg-fiber-dark/70 text-fiber-muted/95 border-fiber-border hover:text-white/95'
+                                  }`}
+                                >
+                                  Local RPC Node
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => onNodeModeChange?.('browser-passkey')}
+                                  className={`px-2.5 py-2 text-[11px] font-mono uppercase tracking-wider rounded-lg border transition-all ${
+                                    nodeMode === 'browser-passkey'
+                                      ? 'bg-fiber-accent/20 text-fiber-accent border-fiber-accent/60'
+                                      : 'bg-fiber-dark/70 text-fiber-muted/95 border-fiber-border hover:text-white/95'
+                                  }`}
+                                >
+                                  Browser Passkey
+                                </button>
                               </div>
                             </div>
+
+                            {nodeMode === 'local-rpc' ? (
+                              <div>
+                                <label className="block text-xs text-fiber-muted/95 mb-2 font-mono uppercase tracking-wider">
+                                  Connect To Fiber Node Via RPC URL
+                                </label>
+                                <div className="relative group">
+                                  <input
+                                    ref={inputRef}
+                                    type="text"
+                                    value={rpcUrlValue || rpcUrl}
+                                    onChange={(e) => onRpcUrlChange?.(e.target.value)}
+                                    className="w-full px-3 py-2 pr-10 bg-fiber-dark border border-fiber-border rounded-lg text-sm font-mono text-white focus:outline-none focus:border-fiber-accent focus:ring-1 focus:ring-fiber-accent/30 hover:bg-fiber-surface/50 transition-all duration-200"
+                                    placeholder={rpcUrl}
+                                  />
+                                  <div className="absolute right-3 top-1/2 -translate-y-1/2 text-fiber-muted group-hover:text-fiber-accent transition-colors pointer-events-none">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>
+                                  </div>
+                                </div>
+                              </div>
+                            ) : (
+                              <div className="space-y-2">
+                                <label className="block text-xs text-fiber-muted/95 font-mono uppercase tracking-wider">
+                                  Browser Node Identity
+                                </label>
+                                <input
+                                  type="text"
+                                  value={passkeyDisplayName}
+                                  onChange={(e) => onPasskeyDisplayNameChange?.(e.target.value)}
+                                  className="w-full px-3 py-2 bg-fiber-dark border border-fiber-border rounded-lg text-sm font-mono text-white focus:outline-none focus:border-fiber-accent focus:ring-1 focus:ring-fiber-accent/30 hover:bg-fiber-surface/50 transition-all duration-200"
+                                  placeholder="Fiber Audio Listener"
+                                />
+                                <p className="text-[11px] text-fiber-muted/90">
+                                  Requires secure context (HTTPS or localhost) and passkey PRF support.
+                                </p>
+                                <p className={`text-[11px] font-mono ${passkeySupported === false ? 'text-red-400' : 'text-fiber-accent'}`}>
+                                  Passkey Support: {passkeySupported === null ? 'Checking...' : passkeySupported ? 'Available' : 'Unavailable'}
+                                </p>
+                                <p className="text-[11px] font-mono text-fiber-muted/95">
+                                  Passkey State: {passkeyConfigured ? 'Configured' : 'Not registered yet'}
+                                </p>
+                                <p className="text-[11px] font-mono text-fiber-muted/95">
+                                  Browser Node State: {browserNodeState}
+                                </p>
+                              </div>
+                            )}
                           </div>
                         ) : null
                       }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -289,17 +289,6 @@ export function Header({
                               <div className="grid grid-cols-2 gap-2">
                                 <button
                                   type="button"
-                                  onClick={() => onNodeModeChange?.('local-rpc')}
-                                  className={`px-2.5 py-2 text-[11px] font-mono uppercase tracking-wider rounded-lg border transition-all ${
-                                    nodeMode === 'local-rpc'
-                                      ? 'bg-fiber-accent/20 text-fiber-accent border-fiber-accent/60'
-                                      : 'bg-fiber-dark/70 text-fiber-muted/95 border-fiber-border hover:text-white/95'
-                                  }`}
-                                >
-                                  Local RPC Node
-                                </button>
-                                <button
-                                  type="button"
                                   onClick={() => onNodeModeChange?.('browser-passkey')}
                                   className={`px-2.5 py-2 text-[11px] font-mono uppercase tracking-wider rounded-lg border transition-all ${
                                     nodeMode === 'browser-passkey'
@@ -308,6 +297,17 @@ export function Header({
                                   }`}
                                 >
                                   Browser Passkey
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => onNodeModeChange?.('local-rpc')}
+                                  className={`px-2.5 py-2 text-[11px] font-mono uppercase tracking-wider rounded-lg border transition-all ${
+                                    nodeMode === 'local-rpc'
+                                      ? 'bg-fiber-accent/20 text-fiber-accent border-fiber-accent/60'
+                                      : 'bg-fiber-dark/70 text-fiber-muted/95 border-fiber-border hover:text-white/95'
+                                  }`}
+                                >
+                                  Local RPC Node
                                 </button>
                               </div>
                             </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -142,6 +142,15 @@ export function Header({
     return { text: 'Node Connected', color: 'bg-fiber-accent' };
   };
 
+  const getModeButtonClasses = (isActive: boolean) => {
+    const baseClasses =
+      'px-2.5 py-2 text-[11px] font-mono uppercase tracking-wider rounded-lg border transition-all';
+    if (isActive) {
+      return `${baseClasses} bg-fiber-accent/20 text-fiber-accent border-fiber-accent/60`;
+    }
+    return `${baseClasses} bg-fiber-dark/70 text-fiber-muted/95 border-fiber-border hover:text-white/95`;
+  };
+
   const buttonStatus = getButtonStatus();
 
   return (
@@ -290,22 +299,14 @@ export function Header({
                                 <button
                                   type="button"
                                   onClick={() => onNodeModeChange?.('browser-passkey')}
-                                  className={`px-2.5 py-2 text-[11px] font-mono uppercase tracking-wider rounded-lg border transition-all ${
-                                    nodeMode === 'browser-passkey'
-                                      ? 'bg-fiber-accent/20 text-fiber-accent border-fiber-accent/60'
-                                      : 'bg-fiber-dark/70 text-fiber-muted/95 border-fiber-border hover:text-white/95'
-                                  }`}
+                                  className={getModeButtonClasses(nodeMode === 'browser-passkey')}
                                 >
                                   Browser Passkey
                                 </button>
                                 <button
                                   type="button"
                                   onClick={() => onNodeModeChange?.('local-rpc')}
-                                  className={`px-2.5 py-2 text-[11px] font-mono uppercase tracking-wider rounded-lg border transition-all ${
-                                    nodeMode === 'local-rpc'
-                                      ? 'bg-fiber-accent/20 text-fiber-accent border-fiber-accent/60'
-                                      : 'bg-fiber-dark/70 text-fiber-muted/95 border-fiber-border hover:text-white/95'
-                                  }`}
+                                  className={getModeButtonClasses(nodeMode === 'local-rpc')}
                                 >
                                   Local RPC Node
                                 </button>

--- a/src/components/NodeStatus.tsx
+++ b/src/components/NodeStatus.tsx
@@ -309,7 +309,7 @@ export function NodeStatus({
         {!recipientPubkey && isConnected && (
           <div className="mt-4 p-3 rounded-lg bg-red-500/10 border border-red-500/30">
             <p className="text-xs text-red-400 font-mono">
-              Recipient pubkey not configured. The site owner needs to set NEXT_PUBLIC_RECIPIENT_PUBKEY.
+              Recipient pubkey is unavailable from backend /node-info. Check backend Fiber RPC connectivity and node-info compatibility.
             </p>
           </div>
         )}

--- a/src/components/NodeStatus.tsx
+++ b/src/components/NodeStatus.tsx
@@ -130,7 +130,7 @@ export function NodeStatus({
 
       <div className="relative z-10">
           {/* Header */}
-          <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center mb-4">
             <div className="flex items-center gap-3">
               <div className="relative">
                 <motion.div
@@ -160,20 +160,6 @@ export function NodeStatus({
               <h3 className="text-sm font-mono uppercase tracking-wider text-fiber-muted/95">
                 Fiber Node
               </h3>
-            </div>
-
-            <div className="flex items-center gap-2">
-              <button
-                onClick={handleConnectToggle}
-                disabled={isConnecting}
-                className={`px-3 py-1.5 text-xs font-mono uppercase tracking-wider rounded-lg transition-all border ${
-                  isConnected
-                    ? 'bg-fiber-border/90 text-white/90 border-fiber-border hover:bg-red-500/20 hover:text-red-300 hover:border-red-500/50'
-                    : 'bg-fiber-accent/20 text-fiber-accent hover:bg-fiber-accent/30 border border-fiber-accent/50'
-                } disabled:opacity-50 disabled:cursor-not-allowed`}
-              >
-                {isConnecting ? 'Connecting...' : isConnected ? 'Disconnect' : 'Connect'}
-              </button>
             </div>
           </div>
 
@@ -272,27 +258,6 @@ export function NodeStatus({
             </div>
 
             </motion.div>
-          ) : !isConnecting && !error ? (
-            <div className="text-center py-4">
-              <div className="w-12 h-12 mx-auto mb-3 rounded-full bg-fiber-border/50 flex items-center justify-center">
-                <svg
-                  className="w-6 h-6 text-fiber-muted"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={1.5}
-                    d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-                  />
-                </svg>
-              </div>
-              <p className="text-sm text-fiber-muted">
-                Connect to your local Fiber node to enable streaming payments
-              </p>
-            </div>
           ) : null}
 
         {/* Recipient pubkey (read-only, set by deployer) */}
@@ -424,6 +389,21 @@ export function NodeStatus({
             </div>
           </div>
         )}
+
+        {/* Connect / Disconnect action */}
+        <div className="mt-4 pt-4 border-t border-fiber-border/50">
+          <button
+            onClick={handleConnectToggle}
+            disabled={isConnecting}
+            className={`w-full px-3 py-2.5 text-xs font-mono uppercase tracking-wider rounded-lg transition-all border ${
+              isConnected
+                ? 'bg-fiber-border/90 text-white/90 border-fiber-border hover:bg-red-500/20 hover:text-red-300 hover:border-red-500/50'
+                : 'bg-fiber-accent/20 text-fiber-accent hover:bg-fiber-accent/30 border-fiber-accent/50'
+            } disabled:opacity-50 disabled:cursor-not-allowed`}
+          >
+            {isConnecting ? 'Connecting...' : isConnected ? 'Disconnect' : 'Connect'}
+          </button>
+        </div>
       </div>
 
       {/* Connection Error Modal */}

--- a/src/hooks/use-fiber-node.ts
+++ b/src/hooks/use-fiber-node.ts
@@ -1,7 +1,23 @@
 'use client';
 
-import { useState, useCallback, useRef } from 'react';
-import { FiberRpcClient, NodeInfo, Channel, PeerInfo, ChannelState, toHex, fromHex, ckbToShannon, formatShannon } from '@/lib/fiber-rpc';
+import { useState, useCallback, useRef, useEffect } from 'react';
+import {
+  FiberRpcClient,
+  NodeInfo,
+  Channel,
+  PeerInfo,
+  ChannelState,
+  toHex,
+  fromHex,
+  ckbToShannon,
+  formatShannon,
+} from '@/lib/fiber-rpc';
+import {
+  FiberBrowserNode,
+  PasskeyCredentialProvider,
+  type BrowserNodeState,
+} from '@fiber-pay/sdk/browser';
+import type { StreamingPaymentClient } from '@/lib/streaming-payment';
 
 export type ChannelStatus =
   | 'idle'
@@ -11,6 +27,28 @@ export type ChannelStatus =
   | 'waiting_confirmation'
   | 'ready'
   | 'error';
+
+export type NodeConnectionMode = 'local-rpc' | 'browser-passkey';
+
+interface ReadyChannelSummary {
+  state: { state_name: ChannelState };
+  local_balance: string;
+}
+
+interface FiberRuntimeClient extends StreamingPaymentClient {
+  nodeInfo: () => Promise<NodeInfo>;
+  listChannels: (params?: { pubkey?: `0x${string}` }) => Promise<{ channels: Channel[] }>;
+  listPeers: () => Promise<{ peers: PeerInfo[] }>;
+  connectPeer: (params: { address: string; save?: boolean }) => Promise<unknown>;
+  openChannel: (params: {
+    pubkey: `0x${string}`;
+    funding_amount: `0x${string}`;
+    public?: boolean;
+  }) => Promise<unknown>;
+  findPeerIdByPubkey: (pubkey: string) => Promise<string | null>;
+  findChannelToPeer: (peerPubkey: string) => Promise<ReadyChannelSummary | null>;
+  checkPaymentRoute: (targetPubkey: string, amount: string) => Promise<boolean>;
+}
 
 export interface UseFiberNodeResult {
   isConnected: boolean;
@@ -22,6 +60,11 @@ export interface UseFiberNodeResult {
   connect: () => Promise<void>;
   disconnect: () => void;
   refresh: () => Promise<void>;
+  paymentClient: StreamingPaymentClient | null;
+  // Browser passkey mode diagnostics
+  passkeySupported: boolean | null;
+  passkeyConfigured: boolean;
+  browserNodeState: BrowserNodeState;
   // Channel setup
   channelStatus: ChannelStatus;
   channelError: string | null;
@@ -39,6 +82,19 @@ export interface UseFiberNodeResult {
 
 const DEFAULT_FUNDING_AMOUNT_CKB = 1000; // 1000 CKB default funding
 const CKB_RPC_URL = 'https://testnet.ckbapp.dev/';
+const PASSKEY_IDENTIFIER = 'fiber-audio-browser-node';
+
+function normalizePubkey(pubkey: string): string {
+  return pubkey.trim().replace(/^0x/i, '').toLowerCase();
+}
+
+function formatRpcPubkey(pubkey: string): string {
+  const normalized = normalizePubkey(pubkey);
+  if (!/^[0-9a-f]{66}$/.test(normalized)) {
+    throw new Error('Invalid recipient pubkey format. Expected 33-byte compressed secp256k1 pubkey hex.');
+  }
+  return normalized;
+}
 
 function extractPeerIdFromMultiaddr(multiaddr: string): string | null {
   const match = multiaddr.match(/\/(?:p2p|ipfs)\/([^/]+)/i);
@@ -60,18 +116,69 @@ interface JsonRpcResponse<T> {
 interface UseFiberNodeOptions {
   recipientPubkey?: string;
   bootnodeMultiaddr?: string;
+  mode?: NodeConnectionMode;
+  passkeyDisplayName?: string;
+  browserNetwork?: 'testnet' | 'mainnet';
+}
+
+function createBrowserRuntimeClient(node: FiberBrowserNode): FiberRuntimeClient {
+  const runtimeClient: FiberRuntimeClient = {
+    nodeInfo: () => node.getNodeInfo(),
+    listChannels: (params) => node.listChannels(params),
+    listPeers: () => node.listPeers(),
+    connectPeer: (params) => node.connectPeer(params),
+    openChannel: (params) => node.openChannel(params),
+    sendPayment: (params) => node.sendPayment(params),
+    waitForPayment: (paymentHash, options) => node.waitForPayment(paymentHash, options),
+    findPeerIdByPubkey: async (pubkey: string): Promise<string | null> => {
+      const result = await node.listPeers();
+      const targetPubkey = normalizePubkey(pubkey);
+      const peer = result.peers.find((p) => normalizePubkey(p.pubkey) === targetPubkey);
+      return peer?.pubkey || null;
+    },
+    findChannelToPeer: async (peerPubkey: string): Promise<ReadyChannelSummary | null> => {
+      const result = await node.listChannels({
+        pubkey: formatRpcPubkey(peerPubkey) as unknown as `0x${string}`,
+      });
+      const readyChannel = result.channels.find(
+        (ch) => ch.state.state_name === ChannelState.ChannelReady && BigInt(ch.local_balance) > 0n
+      );
+      return readyChannel || null;
+    },
+    checkPaymentRoute: async (targetPubkey: string, amount: string): Promise<boolean> => {
+      const result = await node.sendPayment({
+        target_pubkey: formatRpcPubkey(targetPubkey) as unknown as `0x${string}`,
+        amount: amount as `0x${string}`,
+        keysend: true,
+        dry_run: true,
+      });
+      return result.status !== 'Failed';
+    },
+  };
+
+  return runtimeClient;
 }
 
 export function useFiberNode(rpcUrl: string, options: UseFiberNodeOptions = {}): UseFiberNodeResult {
-  const recipientPubkey = options.recipientPubkey?.trim() || '';
   const bootnodeMultiaddr = options.bootnodeMultiaddr?.trim() || '';
+  const mode = options.mode ?? 'local-rpc';
+  const passkeyDisplayName = options.passkeyDisplayName?.trim() || 'Fiber Audio Listener';
+  const browserNetwork = options.browserNetwork ?? 'testnet';
+
   const [isConnected, setIsConnected] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
   const [nodeInfo, setNodeInfo] = useState<NodeInfo | null>(null);
   const [channels, setChannels] = useState<Channel[]>([]);
   const [peers, setPeers] = useState<PeerInfo[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const clientRef = useRef<FiberRpcClient | null>(null);
+  const [paymentClient, setPaymentClient] = useState<StreamingPaymentClient | null>(null);
+
+  const [passkeySupported, setPasskeySupported] = useState<boolean | null>(null);
+  const [passkeyConfigured, setPasskeyConfigured] = useState(false);
+  const [browserNodeState, setBrowserNodeState] = useState<BrowserNodeState>('idle');
+
+  const clientRef = useRef<FiberRuntimeClient | null>(null);
+  const browserNodeRef = useRef<FiberBrowserNode | null>(null);
 
   // Channel status
   const [channelStatus, setChannelStatus] = useState<ChannelStatus>('idle');
@@ -83,6 +190,34 @@ export function useFiberNode(rpcUrl: string, options: UseFiberNodeOptions = {}):
   const [fundingBalanceError, setFundingBalanceError] = useState<string | null>(null);
   const channelSetupCanceledRef = useRef(false);
   const channelTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    let disposed = false;
+
+    const probe = async () => {
+      try {
+        const supported = await PasskeyCredentialProvider.isSupported();
+        if (!disposed) {
+          setPasskeySupported(supported);
+        }
+      } catch {
+        if (!disposed) {
+          setPasskeySupported(false);
+        }
+      }
+
+      if (!disposed) {
+        const provider = new PasskeyCredentialProvider(PASSKEY_IDENTIFIER);
+        setPasskeyConfigured(provider.isConfigured());
+      }
+    };
+
+    probe();
+
+    return () => {
+      disposed = true;
+    };
+  }, []);
 
   const clearChannelTimer = useCallback(() => {
     if (channelTimerRef.current) {
@@ -208,8 +343,51 @@ export function useFiberNode(rpcUrl: string, options: UseFiberNodeOptions = {}):
     setError(null);
 
     try {
-      const client = new FiberRpcClient({ url: rpcUrl, timeout: 10000 });
+      let client: FiberRuntimeClient;
+
+      if (mode === 'browser-passkey') {
+        if (passkeySupported === false) {
+          throw new Error('Passkey PRF extension is not supported in this browser or context.');
+        }
+
+        const credential = new PasskeyCredentialProvider(PASSKEY_IDENTIFIER);
+
+        if (!credential.isConfigured()) {
+          await credential.register(passkeyDisplayName);
+        }
+
+        setPasskeyConfigured(credential.isConfigured());
+
+        const browserNode = new FiberBrowserNode({
+          network: browserNetwork,
+          credential,
+          nodeConfig: {
+            ckbRpcUrl: CKB_RPC_URL,
+            bootnodes: bootnodeMultiaddr ? [bootnodeMultiaddr] : undefined,
+            databasePrefix: `fiber-audio-${PASSKEY_IDENTIFIER}`,
+          },
+        });
+
+        browserNode.on('stateChange', (state) => {
+          setBrowserNodeState(state);
+        });
+        browserNode.on('error', (err) => {
+          setError(err.message);
+        });
+
+        browserNodeRef.current = browserNode;
+        setBrowserNodeState(browserNode.state);
+
+        await browserNode.start();
+
+        client = createBrowserRuntimeClient(browserNode);
+      } else {
+        const localClient = new FiberRpcClient({ url: rpcUrl, timeout: 10000 });
+        client = localClient as unknown as FiberRuntimeClient;
+      }
+
       clientRef.current = client;
+      setPaymentClient(client);
 
       const info = await client.nodeInfo();
       setNodeInfo(info);
@@ -231,13 +409,36 @@ export function useFiberNode(rpcUrl: string, options: UseFiberNodeOptions = {}):
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to connect to Fiber node');
       setIsConnected(false);
+      setPaymentClient(null);
+      clientRef.current = null;
+      if (browserNodeRef.current) {
+        await browserNodeRef.current.stop().catch(() => {});
+        browserNodeRef.current = null;
+        setBrowserNodeState('idle');
+      }
     } finally {
       setIsConnecting(false);
     }
-  }, [bootnodeMultiaddr, ensureBootnodePeerConnected, fetchFundingBalance, rpcUrl]);
+  }, [
+    mode,
+    passkeySupported,
+    passkeyDisplayName,
+    browserNetwork,
+    bootnodeMultiaddr,
+    rpcUrl,
+    ensureBootnodePeerConnected,
+    fetchFundingBalance,
+  ]);
 
   const disconnect = useCallback(() => {
+    if (browserNodeRef.current) {
+      void browserNodeRef.current.stop().catch(() => {});
+      browserNodeRef.current = null;
+      setBrowserNodeState('idle');
+    }
+
     clientRef.current = null;
+    setPaymentClient(null);
     setIsConnected(false);
     setNodeInfo(null);
     setChannels([]);
@@ -522,6 +723,10 @@ export function useFiberNode(rpcUrl: string, options: UseFiberNodeOptions = {}):
     connect,
     disconnect,
     refresh,
+    paymentClient,
+    passkeySupported,
+    passkeyConfigured,
+    browserNodeState,
     channelStatus,
     channelError,
     channelStateName,

--- a/src/hooks/use-streaming-payment.ts
+++ b/src/hooks/use-streaming-payment.ts
@@ -72,6 +72,7 @@ export function useStreamingPayment(
     config.rpcUrl,
     config.recipientPubkey,
     config.ratePerSecond,
+    config.paymentClient,
   ]);
 
   const start = useCallback(async (episodeId?: string, seconds: number = 30): Promise<StreamGrant | null> => {

--- a/src/lib/streaming-payment.ts
+++ b/src/lib/streaming-payment.ts
@@ -10,10 +10,16 @@ import {
   type ClaimInvoiceResponse,
 } from './stream-auth';
 
+export interface StreamingPaymentClient {
+  sendPayment: FiberRpcClient['sendPayment'];
+  waitForPayment: FiberRpcClient['waitForPayment'];
+}
+
 export interface StreamingPaymentConfig {
   rpcUrl: string;
   recipientPubkey: string;
   ratePerSecond: number; // in CKB (display only — actual pricing comes from backend)
+  paymentClient?: StreamingPaymentClient | null;
 }
 
 export interface PaymentTick {
@@ -39,7 +45,7 @@ export interface StreamGrant {
 export type StreamGrantCallback = (grant: StreamGrant) => void;
 
 export class StreamingPaymentService {
-  private client: FiberRpcClient;
+  private client: StreamingPaymentClient;
   private config: StreamingPaymentConfig;
   private isStreaming = false;
   private totalPaid = 0n;
@@ -54,7 +60,7 @@ export class StreamingPaymentService {
 
   constructor(config: StreamingPaymentConfig) {
     this.config = config;
-    this.client = new FiberRpcClient({ url: config.rpcUrl });
+    this.client = config.paymentClient ?? new FiberRpcClient({ url: config.rpcUrl });
   }
 
   onPayment(callback: PaymentCallback): () => void {


### PR DESCRIPTION
## Summary
- move Connect/Disconnect action to the bottom of the connect panel for a clearer top-to-bottom flow
- prioritize Browser Passkey mode before Local RPC mode in the mode switcher
- remove the disconnected empty-state helper text/icon that was not useful

## Files Changed
- src/components/NodeStatus.tsx
- src/components/Header.tsx

## Validation
- pnpm typecheck
