### PR TITLE
feat: add SDK-based deposit address + QR for channel funding

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
     "hls.js": "^1.6.13",
     "motion": "^12.4.7",
     "next": "15.5.12",
+    "qrcode": "^1.5.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@types/node": "^20",
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "autoprefixer": "^10.4.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       next:
         specifier: 15.5.12
         version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -33,6 +36,9 @@ importers:
       '@types/node':
         specifier: ^20
         version: 20.19.32
+      '@types/qrcode':
+        specifier: ^1.5.6
+        version: 1.5.6
       '@types/react':
         specifier: ^19
         version: 19.2.13
@@ -865,6 +871,9 @@ packages:
   '@types/node@20.19.32':
     resolution: {integrity: sha512-Ez8QE4DMfhjjTsES9K2dwfV258qBui7qxUsoaixZDiTzbde4U12e1pXGNu/ECsUIOi5/zoCxAQxIhQnaUQ2VvA==}
 
+  '@types/qrcode@1.5.6':
+    resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -1258,6 +1267,10 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
   caniuse-lite@1.0.30001768:
     resolution: {integrity: sha512-qY3aDRZC5nWPgHUgIB84WL+nySuo19wk0VJpp/XI9T34lrvkyhRvNVOFJOp2kxClQhiFBu+TaUSudf6oa3vkSA==}
 
@@ -1305,6 +1318,9 @@ packages:
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -1386,6 +1402,10 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -1421,6 +1441,9 @@ packages:
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
@@ -1670,6 +1693,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -1744,6 +1771,10 @@ packages:
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
@@ -2058,6 +2089,10 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -2281,9 +2316,17 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -2292,6 +2335,10 @@ packages:
   p-retry@6.2.1:
     resolution: {integrity: sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==}
     engines: {node: '>=16.17'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -2329,6 +2376,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2408,6 +2459,11 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
@@ -2449,6 +2505,13 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2526,6 +2589,9 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -2909,6 +2975,9 @@ packages:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
 
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
   which-typed-array@1.1.20:
     resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
     engines: {node: '>= 0.4'}
@@ -2933,6 +3002,17 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -3430,6 +3510,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/qrcode@1.5.6':
+    dependencies:
+      '@types/node': 20.19.32
+
   '@types/react-dom@19.2.3(@types/react@19.2.13)':
     dependencies:
       '@types/react': 19.2.13
@@ -3859,6 +3943,8 @@ snapshots:
 
   camelcase-css@2.0.1: {}
 
+  camelcase@5.3.1: {}
+
   caniuse-lite@1.0.30001768: {}
 
   chai@6.2.2: {}
@@ -3905,6 +3991,12 @@ snapshots:
   cli-width@4.1.0: {}
 
   client-only@0.0.1: {}
+
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
 
   clone@1.0.4: {}
 
@@ -3968,6 +4060,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize@1.2.0: {}
+
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
@@ -4002,6 +4096,8 @@ snapshots:
       wrappy: 1.0.2
 
   didyoumean@1.2.2: {}
+
+  dijkstrajs@1.0.3: {}
 
   dlv@1.1.3: {}
 
@@ -4411,6 +4507,11 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -4479,6 +4580,8 @@ snapshots:
   functions-have-names@1.2.3: {}
 
   generator-function@2.0.1: {}
+
+  get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.5.0: {}
 
@@ -4794,6 +4897,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -5021,9 +5128,17 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
 
   p-locate@5.0.0:
     dependencies:
@@ -5034,6 +5149,8 @@ snapshots:
       '@types/retry': 0.12.2
       is-network-error: 1.3.1
       retry: 0.13.1
+
+  p-try@2.2.0: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -5056,6 +5173,8 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  pngjs@5.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -5135,6 +5254,12 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
+
   qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
@@ -5190,6 +5315,10 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  require-directory@2.1.1: {}
+
+  require-main-filename@2.0.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -5290,6 +5419,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  set-blocking@2.0.0: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -5808,6 +5939,8 @@ snapshots:
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
 
+  which-module@2.0.1: {}
+
   which-typed-array@1.1.20:
     dependencies:
       available-typed-arrays: 1.0.7
@@ -5836,6 +5969,27 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  y18n@4.0.3: {}
+
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   yocto-queue@0.1.0: {}
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,7 @@ import { getBackendNodeInfo } from '@/lib/stream-auth';
 // Default configuration
 const DEFAULT_RPC_URL = 'http://127.0.0.1:8229';
 const FAUCET_URL = 'https://testnet.ckbapp.dev/';
+const FUNDING_NETWORK: 'testnet' | 'mainnet' = 'testnet';
 
 // Bootnode multiaddr — for the user's node to join the Fiber network.
 const BOOTNODE_MULTIADDR = process.env.NEXT_PUBLIC_BOOTNODE_MULTIADDR || '';
@@ -91,7 +92,7 @@ export default function Home() {
     bootnodeMultiaddr: BOOTNODE_MULTIADDR,
     mode: nodeMode,
     passkeyDisplayName,
-    browserNetwork: 'testnet',
+    browserNetwork: FUNDING_NETWORK,
   });
 
   const payment = useStreamingPayment({
@@ -152,6 +153,7 @@ export default function Home() {
         isFundingSufficient={fiberNode.isFundingSufficient}
         fundingBalanceError={fiberNode.fundingBalanceError}
         faucetUrl={FAUCET_URL}
+        fundingNetwork={FUNDING_NETWORK}
         recipientPubkey={recipientPubkey}
         recipientMultiaddrConfigured={Boolean(BOOTNODE_MULTIADDR.trim())}
         onCheckRoute={() => fiberNode.checkPaymentRoute(recipientPubkey)}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -29,6 +29,7 @@ interface HeaderProps {
   isFundingSufficient?: boolean;
   fundingBalanceError?: string | null;
   faucetUrl?: string;
+  fundingNetwork?: 'testnet' | 'mainnet';
   onCheckRoute?: () => void;
   onOpenChannel?: () => void;
   onCancelSetup?: () => void;
@@ -71,6 +72,7 @@ export function Header({
   isFundingSufficient = false,
   fundingBalanceError,
   faucetUrl,
+  fundingNetwork = 'testnet',
   onCheckRoute,
   onOpenChannel,
   onCancelSetup,
@@ -282,6 +284,7 @@ export function Header({
                       isFundingSufficient={isFundingSufficient}
                       fundingBalanceError={fundingBalanceError}
                       faucetUrl={faucetUrl}
+                      fundingNetwork={fundingNetwork}
                       recipientPubkey={recipientPubkey}
                       recipientMultiaddrConfigured={recipientMultiaddrConfigured}
                       onCheckRoute={onCheckRoute}

--- a/src/components/NodeStatus.tsx
+++ b/src/components/NodeStatus.tsx
@@ -3,8 +3,9 @@
 import { ReactNode, useState, useEffect, useRef } from 'react';
 import { motion } from 'motion/react';
 import { ChannelStatus } from '@/hooks/use-fiber-node';
-import { NodeInfo } from '@/lib/fiber-rpc';
+import { NodeInfo, scriptToAddress } from '@/lib/fiber-rpc';
 import { ConnectionErrorModal } from './ConnectionErrorModal';
+import QRCode from 'qrcode';
 
 interface NodeStatusProps {
   isConnected: boolean;
@@ -27,6 +28,7 @@ interface NodeStatusProps {
   isFundingSufficient?: boolean;
   fundingBalanceError?: string | null;
   faucetUrl?: string;
+  fundingNetwork?: 'testnet' | 'mainnet';
   onCheckRoute?: () => void;
   onOpenChannel?: () => void;
   onCancelSetup?: () => void;
@@ -56,6 +58,7 @@ export function NodeStatus({
   isFundingSufficient = false,
   fundingBalanceError,
   faucetUrl,
+  fundingNetwork = 'testnet',
   onCheckRoute,
   onOpenChannel,
   onCancelSetup,
@@ -65,7 +68,12 @@ export function NodeStatus({
   onRequestEditUrl,
 }: NodeStatusProps) {
   const [showErrorModal, setShowErrorModal] = useState(false);
+  const [fundingAddress, setFundingAddress] = useState<string | null>(null);
+  const [fundingAddressError, setFundingAddressError] = useState<string | null>(null);
+  const [fundingQrDataUrl, setFundingQrDataUrl] = useState<string | null>(null);
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle');
   const wasConnectingRef = useRef(false);
+  const copyResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Show error modal only once per failed connect attempt.
   useEffect(() => {
@@ -81,6 +89,89 @@ export function NodeStatus({
 
     wasConnectingRef.current = isConnecting;
   }, [error, isConnecting, isConnected]);
+
+  useEffect(() => {
+    if (!isConnected || !nodeInfo) {
+      setFundingAddress(null);
+      setFundingAddressError(null);
+      return;
+    }
+
+    try {
+      const address = scriptToAddress(nodeInfo.default_funding_lock_script, fundingNetwork);
+      setFundingAddress(address);
+      setFundingAddressError(null);
+    } catch (err) {
+      setFundingAddress(null);
+      setFundingAddressError(err instanceof Error ? err.message : 'Failed to derive funding address');
+    }
+  }, [fundingNetwork, isConnected, nodeInfo]);
+
+  useEffect(() => {
+    let canceled = false;
+
+    const buildQrCode = async () => {
+      if (!fundingAddress) {
+        setFundingQrDataUrl(null);
+        return;
+      }
+
+      try {
+        const dataUrl = await QRCode.toDataURL(fundingAddress, {
+          width: 192,
+          margin: 1,
+          errorCorrectionLevel: 'M',
+          color: {
+            dark: '#e8f0ff',
+            light: '#00000000',
+          },
+        });
+
+        if (!canceled) {
+          setFundingQrDataUrl(dataUrl);
+        }
+      } catch {
+        if (!canceled) {
+          setFundingQrDataUrl(null);
+        }
+      }
+    };
+
+    void buildQrCode();
+
+    return () => {
+      canceled = true;
+    };
+  }, [fundingAddress]);
+
+  useEffect(() => {
+    return () => {
+      if (copyResetTimerRef.current) {
+        clearTimeout(copyResetTimerRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopyFundingAddress = async () => {
+    if (!fundingAddress) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(fundingAddress);
+      setCopyStatus('copied');
+    } catch {
+      setCopyStatus('failed');
+    }
+
+    if (copyResetTimerRef.current) {
+      clearTimeout(copyResetTimerRef.current);
+    }
+
+    copyResetTimerRef.current = setTimeout(() => {
+      setCopyStatus('idle');
+    }, 2000);
+  };
 
   const handleConnectToggle = () => {
     if (isConnected) {
@@ -234,6 +325,75 @@ export function NodeStatus({
               </div>
             )}
 
+            {!isFundingSufficient && (
+              <div className="p-3 rounded-lg bg-fiber-warning/10 border border-fiber-warning/30 space-y-3">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-xs text-fiber-warning font-mono uppercase tracking-wider">
+                    Funding Top-up Needed
+                  </p>
+                  <span className="text-[11px] text-fiber-muted/95 font-mono uppercase tracking-wider">
+                    {fundingNetwork}
+                  </span>
+                </div>
+
+                <p className="text-xs text-fiber-muted/95">
+                  Funding balance is below <span className="text-white/95">{fundingAmountCkb} CKB</span>. Deposit more CKB to this address before opening a channel.
+                </p>
+
+                {fundingAddress ? (
+                  <>
+                    <div className="rounded-lg border border-fiber-border/70 bg-fiber-dark/80 p-2.5">
+                      <p className="text-[11px] text-fiber-muted/95 font-mono uppercase tracking-wider mb-1.5">
+                        Deposit Address
+                      </p>
+                      <p className="text-[11px] text-white/95 font-mono break-all leading-relaxed">
+                        {fundingAddress}
+                      </p>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={handleCopyFundingAddress}
+                        className="px-2.5 py-1.5 text-[11px] font-mono uppercase tracking-wider rounded border border-fiber-accent/60 text-fiber-accent hover:bg-fiber-accent/20 transition-colors"
+                      >
+                        {copyStatus === 'copied' ? 'Copied' : copyStatus === 'failed' ? 'Copy Failed' : 'Copy Address'}
+                      </button>
+
+                      {faucetUrl && (
+                        <a
+                          href={faucetUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="px-2.5 py-1.5 text-[11px] font-mono uppercase tracking-wider rounded border border-fiber-warning/40 text-fiber-warning hover:bg-fiber-warning/10 transition-colors"
+                        >
+                          Go to Faucet
+                        </a>
+                      )}
+                    </div>
+
+                    {fundingQrDataUrl && (
+                      <div className="inline-flex flex-col gap-1.5 rounded-lg border border-fiber-border/70 bg-fiber-dark/80 p-2">
+                        <p className="text-[10px] text-fiber-muted/95 font-mono uppercase tracking-wider">
+                          Scan to Deposit
+                        </p>
+                        <img
+                          src={fundingQrDataUrl}
+                          alt="Funding address QR code"
+                          className="w-40 h-40 rounded bg-white/5"
+                        />
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <p className="text-xs text-red-300/90 font-mono">
+                    Unable to derive deposit address from funding lock script.
+                    {fundingAddressError ? ` ${fundingAddressError}` : ''}
+                  </p>
+                )}
+              </div>
+            )}
+
             <div className="p-3 rounded-lg bg-fiber-dark/75 border border-fiber-border/60">
               <p className="text-xs text-fiber-muted/95 font-mono uppercase tracking-wider mb-1">
                 Node ID
@@ -348,7 +508,7 @@ export function NodeStatus({
             {!isFundingSufficient && (channelStatus === 'no_route' || channelStatus === 'error') && (
               <div className="mb-2 p-2 rounded-lg bg-red-500/10 border border-red-500/30">
                 <p className="text-xs text-red-400">
-                  Funding balance is below {fundingAmountCkb} CKB. Please top up from faucet first before opening a channel.
+                  Funding balance is below {fundingAmountCkb} CKB. Please top up first before opening a channel.
                   {faucetUrl && (
                     <>
                       {' '}

--- a/src/components/NodeStatus.tsx
+++ b/src/components/NodeStatus.tsx
@@ -71,6 +71,7 @@ export function NodeStatus({
   const [fundingAddress, setFundingAddress] = useState<string | null>(null);
   const [fundingAddressError, setFundingAddressError] = useState<string | null>(null);
   const [fundingQrDataUrl, setFundingQrDataUrl] = useState<string | null>(null);
+  const [fundingQrError, setFundingQrError] = useState<string | null>(null);
   const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle');
   const wasConnectingRef = useRef(false);
   const copyResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -113,12 +114,14 @@ export function NodeStatus({
     const buildQrCode = async () => {
       if (!fundingAddress) {
         setFundingQrDataUrl(null);
+        setFundingQrError(null);
         return;
       }
 
       try {
+        setFundingQrError(null);
         const dataUrl = await QRCode.toDataURL(fundingAddress, {
-          width: 192,
+          width: 160,
           margin: 1,
           errorCorrectionLevel: 'M',
           color: {
@@ -133,6 +136,7 @@ export function NodeStatus({
       } catch {
         if (!canceled) {
           setFundingQrDataUrl(null);
+          setFundingQrError('Failed to generate funding QR code. You can still copy the address manually.');
         }
       }
     };
@@ -383,6 +387,10 @@ export function NodeStatus({
                           className="w-40 h-40 rounded bg-white/5"
                         />
                       </div>
+                    )}
+
+                    {fundingQrError && (
+                      <p className="text-xs text-red-300/90 font-mono">{fundingQrError}</p>
                     )}
                   </>
                 ) : (

--- a/src/lib/fiber-rpc.ts
+++ b/src/lib/fiber-rpc.ts
@@ -8,6 +8,7 @@ import {
   ckbToShannons,
   shannonsToCkb,
   ChannelState,
+  scriptToAddress as sdkScriptToAddress,
 } from '@fiber-pay/sdk';
 
 // Re-export ChannelState from SDK
@@ -16,6 +17,7 @@ export { ChannelState };
 // Re-export utility functions with backward-compatible names
 export const toHex = sdkToHex;
 export const fromHex = sdkFromHex;
+export const scriptToAddress = sdkScriptToAddress;
 
 // Shannon conversion (1 CKB = 10^8 shannon)
 export const SHANNON_PER_CKB = 100_000_000n;


### PR DESCRIPTION
## Summary\n- derive funding deposit address from node default funding lock script via @fiber-pay/sdk scriptToAddress\n- add funding top-up panel in node status when balance is below required channel funding\n- show deposit address, copy action, QR code, and faucet entry to unblock channel opening\n- pass explicit funding network from page -> header -> node status for address encoding consistency\n\n## Validation\n- pnpm typecheck\n