### PR TITLE
fix: faucet link and connect dropdown overflow

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ import { getBackendNodeInfo } from '@/lib/stream-auth';
 
 // Default configuration
 const DEFAULT_RPC_URL = 'http://127.0.0.1:8229';
-const FAUCET_URL = 'https://testnet.ckbapp.dev/';
+const FAUCET_URL = 'https://faucet.nervos.org/';
 const FUNDING_NETWORK: 'testnet' | 'mainnet' = 'testnet';
 
 // Bootnode multiaddr — for the user's node to join the Fiber network.

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -263,7 +263,7 @@ export function Header({
                   transition={{ duration: 0.2 }}
                   className="absolute right-0 top-full mt-2 w-[400px] max-w-[90vw] z-50"
                 >
-                  <div className="rounded-2xl bg-fiber-surface/95 backdrop-blur-md border border-fiber-border/90 shadow-2xl shadow-black/50 overflow-hidden">
+                  <div className="rounded-2xl bg-fiber-surface/95 backdrop-blur-md border border-fiber-border/90 shadow-2xl shadow-black/50 overflow-x-hidden overflow-y-auto max-h-[80vh]">
                     <NodeStatus
                       isConnected={isConnected}
                       isConnecting={isConnecting}


### PR DESCRIPTION
## Summary\n- update faucet URL to a web page endpoint that opens correctly instead of triggering a binary download\n- constrain connect dropdown card height and enable vertical scrolling to avoid viewport overflow\n\n## Validation\n- pnpm typecheck\n