### PR TITLE
feat: support separate browser bootnode multiaddr env

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -6,6 +6,10 @@ NEXT_PUBLIC_BACKEND_BASE_URL=http://localhost:8787
 # the developer node (whose pubkey is auto-fetched from backend /node-info).
 NEXT_PUBLIC_BOOTNODE_MULTIADDR=/ip4/18.162.235.225/tcp/8119/p2p/QmXen3eUHhywmutEzydCsW4hXBoeVmdET2FJvMX69XJ1Eo
 
+# Optional browser-passkey (WASM) bootnode multiaddr.
+# Browser nodes require websocket-compatible addresses (wss://), for example:
+NEXT_PUBLIC_BOOTNODE_MULTIADDR_BROWSER=/dns4/bottle.fiber.channel/tcp/443/wss/p2p/QmXen3eUHhywmutEzydCsW4hXBoeVmdET2FJvMX69XJ1Eo
+
 # How many seconds of audio to purchase per invoice (default 30).
 # Each click of play (or auto-extend) buys this many seconds at the backend's
 # configured price-per-second.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ NEXT_PUBLIC_BACKEND_BASE_URL=http://localhost:8787
 # Optional: Bootnode multiaddr for listener auto-bootstrap
 NEXT_PUBLIC_BOOTNODE_MULTIADDR=/ip4/127.0.0.1/tcp/8228/p2p/Qm...
 
+# Optional: Browser-passkey (WASM) bootnode multiaddr (must be websocket-compatible)
+# If unset, browser mode falls back to NEXT_PUBLIC_BOOTNODE_MULTIADDR
+NEXT_PUBLIC_BOOTNODE_MULTIADDR_BROWSER=/dns4/bottle.fiber.channel/tcp/443/wss/p2p/Qm...
+
 # Optional: Payment interval (default: 10 seconds)
 NEXT_PUBLIC_PAYMENT_INTERVAL_MS=10000
 ```

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,6 +19,7 @@ const FUNDING_NETWORK: 'testnet' | 'mainnet' = 'testnet';
 
 // Bootnode multiaddr — for the user's node to join the Fiber network.
 const BOOTNODE_MULTIADDR = process.env.NEXT_PUBLIC_BOOTNODE_MULTIADDR || '';
+const BOOTNODE_MULTIADDR_BROWSER = process.env.NEXT_PUBLIC_BOOTNODE_MULTIADDR_BROWSER || '';
 
 // Default cover image for episodes
 const DEFAULT_COVER_URL = '/default-cover.svg';
@@ -87,9 +88,17 @@ export default function Home() {
       });
   }, []);
 
+  const resolvedBrowserBootnodeMultiaddr =
+    BOOTNODE_MULTIADDR_BROWSER.trim() || BOOTNODE_MULTIADDR.trim();
+  const recipientMultiaddrConfigured =
+    nodeMode === 'browser-passkey'
+      ? Boolean(resolvedBrowserBootnodeMultiaddr)
+      : Boolean(BOOTNODE_MULTIADDR.trim());
+
   const fiberNode = useFiberNode(rpcUrl, {
     recipientPubkey,
     bootnodeMultiaddr: BOOTNODE_MULTIADDR,
+    browserBootnodeMultiaddr: resolvedBrowserBootnodeMultiaddr,
     mode: nodeMode,
     passkeyDisplayName,
     browserNetwork: FUNDING_NETWORK,
@@ -155,7 +164,7 @@ export default function Home() {
         faucetUrl={FAUCET_URL}
         fundingNetwork={FUNDING_NETWORK}
         recipientPubkey={recipientPubkey}
-        recipientMultiaddrConfigured={Boolean(BOOTNODE_MULTIADDR.trim())}
+        recipientMultiaddrConfigured={recipientMultiaddrConfigured}
         onCheckRoute={() => fiberNode.checkPaymentRoute(recipientPubkey)}
         onOpenChannel={() => fiberNode.setupChannel()}
         onCancelSetup={fiberNode.cancelChannelSetup}

--- a/src/components/ConnectionErrorModal.tsx
+++ b/src/components/ConnectionErrorModal.tsx
@@ -127,6 +127,8 @@ export function ConnectionErrorModal({ isOpen, onClose, error, rpcUrl, onRequest
   const { Icon } = config;
 
   const bootnodeMultiaddr = process.env.NEXT_PUBLIC_BOOTNODE_MULTIADDR || '';
+  const browserBootnodeMultiaddr = process.env.NEXT_PUBLIC_BOOTNODE_MULTIADDR_BROWSER || '';
+  const hasBootnodeConfigured = Boolean(bootnodeMultiaddr.trim() || browserBootnodeMultiaddr.trim());
 
   if (!mounted) return null;
 
@@ -189,9 +191,9 @@ export function ConnectionErrorModal({ isOpen, onClose, error, rpcUrl, onRequest
                     <p className='mt-2 text-xs font-mono text-white/90 bg-black/30 p-2 rounded'>
                       Make sure your Fiber node is running with CORS enabled at: <code className="text-fiber-accent">{rpcUrl}</code>
                     </p>
-                    {!bootnodeMultiaddr.trim() && (
+                    {!hasBootnodeConfigured && (
                       <p className="mt-2 text-xs font-mono text-fiber-warning bg-fiber-warning/10 border border-fiber-warning/30 p-2 rounded">
-                        Optional: set NEXT_PUBLIC_BOOTNODE_MULTIADDR to enable automatic peer bootstrap for users without preconfigured peers.
+                        Optional: set NEXT_PUBLIC_BOOTNODE_MULTIADDR (local RPC mode) and/or NEXT_PUBLIC_BOOTNODE_MULTIADDR_BROWSER (browser passkey mode) to enable automatic peer bootstrap.
                       </p>
                     )}
                   </div>

--- a/src/components/NodeStatus.tsx
+++ b/src/components/NodeStatus.tsx
@@ -449,7 +449,7 @@ export function NodeStatus({
         {recipientPubkey && isConnected && !recipientMultiaddrConfigured && (
           <div className="mt-3 p-3 rounded-lg bg-fiber-warning/10 border border-fiber-warning/30">
             <p className="text-xs text-fiber-warning font-mono">
-              Auto peer bootstrap disabled. Optionally set NEXT_PUBLIC_BOOTNODE_MULTIADDR so users without preconfigured peers can join the network automatically.
+              Auto peer bootstrap disabled. Set NEXT_PUBLIC_BOOTNODE_MULTIADDR for local RPC mode and/or NEXT_PUBLIC_BOOTNODE_MULTIADDR_BROWSER for browser passkey mode.
             </p>
           </div>
         )}

--- a/src/hooks/use-fiber-node.ts
+++ b/src/hooks/use-fiber-node.ts
@@ -116,6 +116,7 @@ interface JsonRpcResponse<T> {
 interface UseFiberNodeOptions {
   recipientPubkey?: string;
   bootnodeMultiaddr?: string;
+  browserBootnodeMultiaddr?: string;
   mode?: NodeConnectionMode;
   passkeyDisplayName?: string;
   browserNetwork?: 'testnet' | 'mainnet';
@@ -160,8 +161,17 @@ function createBrowserRuntimeClient(node: FiberBrowserNode): FiberRuntimeClient 
 }
 
 export function useFiberNode(rpcUrl: string, options: UseFiberNodeOptions = {}): UseFiberNodeResult {
-  const bootnodeMultiaddr = options.bootnodeMultiaddr?.trim() || '';
   const mode = options.mode ?? 'local-rpc';
+  const localBootnodeMultiaddr = options.bootnodeMultiaddr?.trim() || '';
+  const browserBootnodeMultiaddr = options.browserBootnodeMultiaddr?.trim() || '';
+  const activeBootnodeMultiaddr =
+    mode === 'browser-passkey'
+      ? browserBootnodeMultiaddr || localBootnodeMultiaddr
+      : localBootnodeMultiaddr;
+  const activeBootnodeEnvHint =
+    mode === 'browser-passkey'
+      ? 'NEXT_PUBLIC_BOOTNODE_MULTIADDR_BROWSER (fallback NEXT_PUBLIC_BOOTNODE_MULTIADDR)'
+      : 'NEXT_PUBLIC_BOOTNODE_MULTIADDR';
   const passkeyDisplayName = options.passkeyDisplayName?.trim() || 'Fiber Audio Listener';
   const browserNetwork = options.browserNetwork ?? 'testnet';
 
@@ -286,11 +296,11 @@ export function useFiberNode(rpcUrl: string, options: UseFiberNodeOptions = {}):
 
   const ensureBootnodePeerConnected = useCallback(async (): Promise<string | null> => {
     const client = clientRef.current;
-    if (!client || !bootnodeMultiaddr) {
+    if (!client || !activeBootnodeMultiaddr) {
       return null;
     }
 
-    const targetPeerId = extractPeerIdFromMultiaddr(bootnodeMultiaddr);
+    const targetPeerId = extractPeerIdFromMultiaddr(activeBootnodeMultiaddr);
 
     const peersBefore = await client.listPeers();
     if (targetPeerId) {
@@ -305,7 +315,7 @@ export function useFiberNode(rpcUrl: string, options: UseFiberNodeOptions = {}):
     const peerPubkeysBefore = new Set(peersBefore.peers.map((peer) => peer.pubkey));
 
     try {
-      await client.connectPeer({ address: bootnodeMultiaddr, save: true });
+      await client.connectPeer({ address: activeBootnodeMultiaddr, save: true });
     } catch {
       // Some runtimes return an error if already connected; we'll verify via listPeers below.
     }
@@ -336,7 +346,7 @@ export function useFiberNode(rpcUrl: string, options: UseFiberNodeOptions = {}):
     }
 
     return null;
-  }, [bootnodeMultiaddr]);
+  }, [activeBootnodeMultiaddr]);
 
   const connect = useCallback(async () => {
     setIsConnecting(true);
@@ -363,7 +373,7 @@ export function useFiberNode(rpcUrl: string, options: UseFiberNodeOptions = {}):
           credential,
           nodeConfig: {
             ckbRpcUrl: CKB_RPC_URL,
-            bootnodes: bootnodeMultiaddr ? [bootnodeMultiaddr] : undefined,
+            bootnodes: activeBootnodeMultiaddr ? [activeBootnodeMultiaddr] : undefined,
             databasePrefix: `fiber-audio-${PASSKEY_IDENTIFIER}`,
           },
         });
@@ -399,7 +409,7 @@ export function useFiberNode(rpcUrl: string, options: UseFiberNodeOptions = {}):
       const peersResult = await client.listPeers();
       setPeers(peersResult.peers || []);
 
-      if (bootnodeMultiaddr) {
+      if (activeBootnodeMultiaddr) {
         await ensureBootnodePeerConnected();
         const refreshedPeersResult = await client.listPeers();
         setPeers(refreshedPeersResult.peers || []);
@@ -424,7 +434,7 @@ export function useFiberNode(rpcUrl: string, options: UseFiberNodeOptions = {}):
     passkeySupported,
     passkeyDisplayName,
     browserNetwork,
-    bootnodeMultiaddr,
+    activeBootnodeMultiaddr,
     rpcUrl,
     ensureBootnodePeerConnected,
     fetchFundingBalance,
@@ -498,10 +508,10 @@ export function useFiberNode(rpcUrl: string, options: UseFiberNodeOptions = {}):
         const testAmount = toHex(ckbToShannon(amount));
 
         const bootnodePubkey = await ensureBootnodePeerConnected();
-        if (bootnodeMultiaddr && !bootnodePubkey) {
+        if (activeBootnodeMultiaddr && !bootnodePubkey) {
           setChannelStatus('no_route');
           setChannelError(
-            'Cannot connect to the public bootnode. Check NEXT_PUBLIC_BOOTNODE_MULTIADDR and make sure the node is reachable.'
+            `Cannot connect to the public bootnode. Check ${activeBootnodeEnvHint} and make sure the node is reachable.`
           );
           return false;
         }
@@ -552,7 +562,7 @@ export function useFiberNode(rpcUrl: string, options: UseFiberNodeOptions = {}):
         return false;
       }
     },
-    [bootnodeMultiaddr, clearChannelTimer, ensureBootnodePeerConnected]
+    [activeBootnodeEnvHint, activeBootnodeMultiaddr, clearChannelTimer, ensureBootnodePeerConnected]
   );
 
   const cancelChannelSetup = useCallback(() => {
@@ -572,8 +582,8 @@ export function useFiberNode(rpcUrl: string, options: UseFiberNodeOptions = {}):
         return false;
       }
 
-      if (!bootnodeMultiaddr) {
-        setChannelError('Public node address is not configured. Set NEXT_PUBLIC_BOOTNODE_MULTIADDR first.');
+      if (!activeBootnodeMultiaddr) {
+        setChannelError(`Public node address is not configured. Set ${activeBootnodeEnvHint} first.`);
         setChannelStatus('error');
         return false;
       }
@@ -601,7 +611,7 @@ export function useFiberNode(rpcUrl: string, options: UseFiberNodeOptions = {}):
         const bootnodePubkey = await ensureBootnodePeerConnected();
         if (!bootnodePubkey) {
           throw new Error(
-            'Failed to connect to public bootnode peer. Ensure NEXT_PUBLIC_BOOTNODE_MULTIADDR is reachable and the public node is online.'
+            `Failed to connect to public bootnode peer. Ensure ${activeBootnodeEnvHint} is reachable and the public node is online.`
           );
         }
 
@@ -687,7 +697,7 @@ export function useFiberNode(rpcUrl: string, options: UseFiberNodeOptions = {}):
         if (normalizedError.includes('peer not connected') || normalizedError.includes('not in your peer list')) {
           setChannelError(
             `Cannot open channel: Public bootnode peer not connected. ` +
-            `Check NEXT_PUBLIC_BOOTNODE_MULTIADDR and make sure the public node is reachable.`
+            `Check ${activeBootnodeEnvHint} and make sure the public node is reachable.`
           );
         } else if (normalizedError.includes('insufficient') || normalizedError.includes('balance') || normalizedError.includes('fund')) {
           setChannelError(
@@ -702,7 +712,8 @@ export function useFiberNode(rpcUrl: string, options: UseFiberNodeOptions = {}):
       }
     },
     [
-      bootnodeMultiaddr,
+      activeBootnodeEnvHint,
+      activeBootnodeMultiaddr,
       clearChannelTimer,
       ensureBootnodePeerConnected,
       fundingBalanceCkb,


### PR DESCRIPTION
## Summary\n- add NEXT_PUBLIC_BOOTNODE_MULTIADDR_BROWSER support for browser-passkey (WASM) mode\n- keep NEXT_PUBLIC_BOOTNODE_MULTIADDR for local-rpc mode\n- browser mode now prefers NEXT_PUBLIC_BOOTNODE_MULTIADDR_BROWSER and falls back to NEXT_PUBLIC_BOOTNODE_MULTIADDR\n- update mode-aware bootnode warnings and setup hints\n- document new env variable in README and .env.local.example\n\n## Validation\n- pnpm typecheck\n